### PR TITLE
Fix Warnings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class ApplicationController < ActionController::Base
-  include Pundit
+  include Pundit::Authorization
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ Bundler.require(*Rails.groups)
 module NotesRails
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 7.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
- Update to non-deprecated Pundit approach
- Fix CSRF deprecation warning by updating to 7.0 defaults
