### PR TITLE
Prevent submitting search form

### DIFF
--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -16,7 +16,7 @@
   </div>
 <% end %>
 
-<form data-controller="filter">
+<form data-controller="filter" onsubmit="return false">
   <input type="search" data-filter-target="filterTextField" data-action="keyup->filter#update" class="form-control mb-2" placeholder="search" />
 
   <div class="list-group mb-3">


### PR DESCRIPTION
Prevent the enter key from submitting the search form, because it works upon keyup instead, and the enter key reloads the page and loses the results